### PR TITLE
Fixed sys.argv AttributeError for embeded python

### DIFF
--- a/localconfig/manager.py
+++ b/localconfig/manager.py
@@ -64,6 +64,9 @@ class LocalConfig(object):
                                   lines.
         :param bool compact_form: Serialize in compact form, such as no new lines between each config key.
         """
+        if not hasattr(sys, 'argv'):
+            sys.argv = ['']
+
         if not last_source and sys.argv and sys.argv[0] and not sys.argv[0].endswith('/pytest'):
             last_source = os.path.join('~', '.config', os.path.basename(sys.argv[0]))
 


### PR DESCRIPTION
For embeded python, version 3.6.8 especially for my case, there is an error:
AttributeError: module 'sys' has no attribute 'argv'
Suggested solution mentioned here [](https://bugs.python.org/issue32573)