### PR TITLE
Add support for non-decimal integers

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -158,7 +158,7 @@ The following types are supported:
 ======= ===========================================
 Type    Example Value
 ======= ===========================================
-int     1
+int     1 0b1101 0o70 0xFF
 float   2.0
 bool    true false yes no on off (case insensitive)
 None    none (case insensitive)

--- a/localconfig/manager.py
+++ b/localconfig/manager.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-from localconfig.utils import is_float, is_int, is_bool, is_none, is_config, CONFIG_KEY_RE, to_bool
+from localconfig.utils import is_float, is_int, is_int_base_n, is_bool, is_none, is_config, CONFIG_KEY_RE, to_bool
 
 NON_ALPHA_NUM = re.compile('[^A-Za-z0-9]')
 NO_DEFAULT_VALUE = 'NO-DEFAULT-VALUE'
@@ -334,6 +334,8 @@ class LocalConfig(object):
             new_value = value
             if is_int(value):
                 new_value = int(value)
+            elif is_int_base_n(value):
+                new_value = int(value, 0)
             elif is_float(value):
                 new_value = float(value)
             elif is_bool(value):

--- a/localconfig/utils.py
+++ b/localconfig/utils.py
@@ -13,6 +13,16 @@ def is_int(value):
     return _is_type(value, int)
 
 
+def is_int_base_n(value):
+    """ Checks if the value is an int """
+    try:
+        # int(value, 0) will autodetect the presence of a base-n prefix in a string
+        int(value, 0)
+        return True
+    except Exception:
+        return False
+
+
 def is_bool(value):
     """ Checks if the value is a bool """
     return value.lower() in ['true', 'false', 'yes', 'no', 'on', 'off']

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -16,6 +16,15 @@ TEST_CONFIG = """\
 # An int value
 int = 1
 
+# A binary int value
+int_binary = 0b11
+
+# An octal int value
+int_octal = 0o77
+
+# A hexadecimal int value
+int_hex = 0xabcd
+
 # A float value
 float = 2.0
 
@@ -55,6 +64,12 @@ COMPACT_TEST_CONFIG = """\
 [types]
 # An int value
 int: 1
+# A binary int value
+int_binary: 0b11
+# An octal int value
+int_octal: 0o77
+# A hexadecimal int value
+int_hex: 0xabcd
 # A float value
 float: 2.0
 # A mid-commented out
@@ -93,6 +108,9 @@ def config():
 
 def test_read(config):
     assert config.types.int == 1
+    assert config.types.int_binary == 0b11
+    assert config.types.int_octal == 0o77
+    assert config.types.int_hex == 0xabcd
     assert config.types.float == 2.0
     assert config.types.true is True
     assert config.types.false is False
@@ -108,6 +126,9 @@ def test_read(config):
     assert {
       ('types', 'string-value'): '# A string value',
       ('types', 'int'): '# An int value',
+      ('types', 'int_binary'): '# A binary int value',
+      ('types', 'int_octal'): '# An octal int value',
+      ('types', 'int_hex'): '# A hexadecimal int value',
       ('types', 'float'): '# A float value',
       ('types', 'true'): '# A mid-commented out\n# comment = value\n\n# A bool value',
       ('types', 'false'): '# A false bool value',
@@ -212,6 +233,9 @@ def test_iter(config):
     assert list(config) == ['types', 'another-section']
     assert [
       ('int', 1),
+      ('int_binary', 0b11),
+      ('int_octal', 0o77),
+      ('int_hex', 0xabcd),
       ('float', 2.0),
       ('true', True),
       ('false', False),
@@ -222,6 +246,9 @@ def test_iter(config):
       'none': None,
       'string-value': 'Value',
       'int': 1,
+      'int_binary': 0b11,
+      'int_octal': 0o77,
+      'int_hex': 0xabcd,
       'float': 2.0,
       'true': True} == dict(list(config.types))
 


### PR DESCRIPTION
When using non-decimal integers in config files, localconfig recognizes them as strings.

This is actually an OK behaviour, but they could be recognized as integers.

An example of config file would be like:

[asd]
relays_status = 0b110111000
file_permissions = 0o755
i2c_address = 0x70
